### PR TITLE
Change to scripts/.gitignore to allow for alternate Fink tree roots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 /installer/contents-*
 /installer/Info.plist
 
-/installer/contents/sw
+/installer/contents/*
 
 /installer/dmg/*.pkg
 /installer/dmg/FinkCommander


### PR DESCRIPTION
Follow up changes to scripts/installer will remove hardcoding /sw (even though /sw will still be the default root)
