### PR TITLE
[buildfink] Add entry about trying to directly access /sw/share/info

### DIFF
--- a/buildfink/etc/catdescs
+++ b/buildfink/etc/catdescs
@@ -46,6 +46,7 @@ nodep: Couldn't resolve dependency
 nofink: No matching version found for fink
 conflict: Conflicting packages
 typeconflict: Conflicting types for 'foo'
+accessing_system_infodir: Trying to write directly to system-infodir
 insufficient_permission: Build process tried to access restricted files (--build-as-nobody)
 chown: Attempted forbidden change in ownership (insufficient permissions)
 f-p-p: Uses system library/header over Fink provided file

--- a/buildfink/etc/filters.xml
+++ b/buildfink/etc/filters.xml
@@ -153,6 +153,7 @@ multiple rules could be matched.
 	<filter name="failures/project/nostatic">error: '(.*)' may not be declared as static</filter>
 	<filter name="failures/project/empty_compiler_flag">  *\-[I]  *\-</filter>
 	<filter name="failures/project/f-p-p">Please fix build process to get consistent use</filter>
+	<filter name="warnings/accessing_system_infodir" flags="i">cp: /sw/share/info/dir.bak: Permission denied</filter>
 	<filter name="failures/project/insufficient_permission" flags="i">(?:install|rm|touch|cp|mv|rmdir|mkdir).*permission denied</filter>
 	<filter name="failures/project/chown">ch(?:own|mod|grp).*Operation not permitted</filter>
 


### PR DESCRIPTION
New non-fatal warning to go into the reports.
