### PR TITLE
point to correct download url for xquartz

### DIFF
--- a/srcinstaller/Install Fink.tool
+++ b/srcinstaller/Install Fink.tool
@@ -18,7 +18,7 @@ XQuartzVersion="2.7.11"
 XQuartzMD5Sum="8e9dbfe2717c8d74c262b3a963597898"
 XQuartzPKGPath="XQuartz.pkg"
 XQuartzFileName="XQuartz-${XQuartzVersion}.dmg"
-XQuartzSourceDLP="http://xquartz.macosforge.org/downloads/SL/${XQuartzFileName}"
+XQuartzSourceDLP="https://dl.bintray.com/xquartz/downloads/${XQuartzFileName}"
 
 
 function fetchBin {


### PR DESCRIPTION
The current version returned:

````
curl: (22) The requested URL returned error: 404 Not Found
error: Unable to fetch http://xquartz.macosforge.org/downloads/SL/XQuartz-2.7.11.dmg
````

So I checked on the xquartz website and found a different URL which worked fine.